### PR TITLE
야놀자 페이 패스워드 설정 API 구현

### DIFF
--- a/src/main/java/kr/co/fastcampus/yanabada/common/exception/PasswordConfirmationException.java
+++ b/src/main/java/kr/co/fastcampus/yanabada/common/exception/PasswordConfirmationException.java
@@ -1,0 +1,7 @@
+package kr.co.fastcampus.yanabada.common.exception;
+
+import static kr.co.fastcampus.yanabada.common.response.ErrorCode.PASSWORD_CONFIRMATION_DOES_NOT_MATCH;
+
+public class PasswordConfirmationException extends BaseException {
+    public PasswordConfirmationException() { super(PASSWORD_CONFIRMATION_DOES_NOT_MATCH.getMessage()); }
+}

--- a/src/main/java/kr/co/fastcampus/yanabada/common/exception/PasswordConfirmationException.java
+++ b/src/main/java/kr/co/fastcampus/yanabada/common/exception/PasswordConfirmationException.java
@@ -3,5 +3,7 @@ package kr.co.fastcampus.yanabada.common.exception;
 import static kr.co.fastcampus.yanabada.common.response.ErrorCode.PASSWORD_CONFIRMATION_DOES_NOT_MATCH;
 
 public class PasswordConfirmationException extends BaseException {
-    public PasswordConfirmationException() { super(PASSWORD_CONFIRMATION_DOES_NOT_MATCH.getMessage()); }
+    public PasswordConfirmationException() {
+        super(PASSWORD_CONFIRMATION_DOES_NOT_MATCH.getMessage());
+    }
 }

--- a/src/main/java/kr/co/fastcampus/yanabada/common/response/ErrorCode.java
+++ b/src/main/java/kr/co/fastcampus/yanabada/common/response/ErrorCode.java
@@ -31,6 +31,7 @@ public enum ErrorCode {
     CANNOT_NEGOTIATE_OWN_PRODUCT("자신이 등록한 상품을 네고할 순 없습니다."),
     CHAT_ROOM_NOT_FOUND_EXCEPTION("존재하지 않은 채팅방입니다."),
     INCORRECT_CHAT_ROOM_MEMBER("채팅방 멤버가 올바르지 않습니다."),
+    PASSWORD_CONFIRMATION_DOES_NOT_MATCH("입력한 비밀번호가 서로 일치하지 않습니다."),
 
     EMAIL_SEND_FAILED("이메일 전송에 실패하였습니다."),
 

--- a/src/main/java/kr/co/fastcampus/yanabada/domain/payment/controller/YanoljaPayController.java
+++ b/src/main/java/kr/co/fastcampus/yanabada/domain/payment/controller/YanoljaPayController.java
@@ -31,7 +31,7 @@ public class YanoljaPayController {
         return ResponseBody.ok(yanoljaPayService.getYanoljaPay(memberId));
     }
 
-    @PostMapping("/payPassword/{memberId}")
+    @PostMapping("/pay-password/{memberId}")
     public ResponseBody<ResponseEntity<?>> setPayPassword(
         @PathVariable("memberId") Long memberId,
         @RequestBody @Valid PayPasswordRequest payPasswordRequest

--- a/src/main/java/kr/co/fastcampus/yanabada/domain/payment/controller/YanoljaPayController.java
+++ b/src/main/java/kr/co/fastcampus/yanabada/domain/payment/controller/YanoljaPayController.java
@@ -1,11 +1,21 @@
 package kr.co.fastcampus.yanabada.domain.payment.controller;
 
+import jakarta.validation.Valid;
+import kr.co.fastcampus.yanabada.common.exception.MemberNotFoundException;
+import kr.co.fastcampus.yanabada.common.exception.PasswordConfirmationException;
+import kr.co.fastcampus.yanabada.common.exception.YanoljaPayNotFoundException;
 import kr.co.fastcampus.yanabada.common.response.ResponseBody;
+import kr.co.fastcampus.yanabada.domain.payment.dto.request.PayPasswordRequest;
 import kr.co.fastcampus.yanabada.domain.payment.dto.response.YanoljaPayHomeResponse;
 import kr.co.fastcampus.yanabada.domain.payment.service.YanoljaPayService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestAttribute;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -19,6 +29,15 @@ public class YanoljaPayController {
     @GetMapping("/{memberId}")
     public ResponseBody<YanoljaPayHomeResponse> getYanoljaPay(@PathVariable Long memberId) {
         return ResponseBody.ok(yanoljaPayService.getYanoljaPay(memberId));
+    }
+
+    @PostMapping("/payPassword/{memberId}")
+    public ResponseBody<ResponseEntity<?>> setPayPassword(
+        @PathVariable("memberId") Long memberId,
+        @RequestBody @Valid PayPasswordRequest payPasswordRequest
+    ) {
+        yanoljaPayService.setPayPassword(memberId, payPasswordRequest);
+        return ResponseBody.ok(ResponseEntity.ok().build());
     }
 }
 

--- a/src/main/java/kr/co/fastcampus/yanabada/domain/payment/controller/YanoljaPayController.java
+++ b/src/main/java/kr/co/fastcampus/yanabada/domain/payment/controller/YanoljaPayController.java
@@ -1,20 +1,14 @@
 package kr.co.fastcampus.yanabada.domain.payment.controller;
 
 import jakarta.validation.Valid;
-import kr.co.fastcampus.yanabada.common.exception.MemberNotFoundException;
-import kr.co.fastcampus.yanabada.common.exception.PasswordConfirmationException;
-import kr.co.fastcampus.yanabada.common.exception.YanoljaPayNotFoundException;
 import kr.co.fastcampus.yanabada.common.response.ResponseBody;
-import kr.co.fastcampus.yanabada.domain.payment.dto.request.PayPasswordRequest;
+import kr.co.fastcampus.yanabada.domain.payment.dto.request.PayPasswordSaveRequest;
 import kr.co.fastcampus.yanabada.domain.payment.dto.response.YanoljaPayHomeResponse;
 import kr.co.fastcampus.yanabada.domain.payment.service.YanoljaPayService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestAttribute;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -32,12 +26,12 @@ public class YanoljaPayController {
     }
 
     @PostMapping("/pay-password/{memberId}")
-    public ResponseBody<ResponseEntity<?>> setPayPassword(
+    public ResponseBody<Void> setPayPassword(
         @PathVariable("memberId") Long memberId,
-        @RequestBody @Valid PayPasswordRequest payPasswordRequest
+        @RequestBody @Valid PayPasswordSaveRequest payPasswordSaveRequest
     ) {
-        yanoljaPayService.setPayPassword(memberId, payPasswordRequest);
-        return ResponseBody.ok(ResponseEntity.ok().build());
+        yanoljaPayService.setPayPassword(memberId, payPasswordSaveRequest);
+        return ResponseBody.ok();
     }
 }
 

--- a/src/main/java/kr/co/fastcampus/yanabada/domain/payment/dto/request/PayPasswordRequest.java
+++ b/src/main/java/kr/co/fastcampus/yanabada/domain/payment/dto/request/PayPasswordRequest.java
@@ -1,0 +1,19 @@
+package kr.co.fastcampus.yanabada.domain.payment.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.Builder;
+
+@Builder
+public record PayPasswordRequest(
+    @NotBlank(message = "패스워드는 공백일 수 없습니다.")
+    @Pattern(regexp = "\\d{6}", message = "패스워드는 6글자이어야 합니다.")
+    String password,
+    @NotBlank(message = "확인용 패스워드도 공백일 수 없습니다.")
+    String confirmPassword
+) {
+
+    public boolean isPasswordMatch() {
+        return this.password.equals(this.confirmPassword);
+    }
+}

--- a/src/main/java/kr/co/fastcampus/yanabada/domain/payment/dto/request/PayPasswordSaveRequest.java
+++ b/src/main/java/kr/co/fastcampus/yanabada/domain/payment/dto/request/PayPasswordSaveRequest.java
@@ -5,7 +5,7 @@ import jakarta.validation.constraints.Pattern;
 import lombok.Builder;
 
 @Builder
-public record PayPasswordRequest(
+public record PayPasswordSaveRequest(
     @NotBlank(message = "패스워드는 공백일 수 없습니다.")
     @Pattern(regexp = "\\d{6}", message = "패스워드는 6글자이어야 합니다.")
     String password,

--- a/src/main/java/kr/co/fastcampus/yanabada/domain/payment/entity/YanoljaPay.java
+++ b/src/main/java/kr/co/fastcampus/yanabada/domain/payment/entity/YanoljaPay.java
@@ -93,4 +93,8 @@ public class YanoljaPay extends BaseEntity {
             balance
         );
     }
+
+    public void savePassword(String password) {
+        this.simplePassword = password;
+    }
 }

--- a/src/main/java/kr/co/fastcampus/yanabada/domain/payment/repository/YanoljaPayRepository.java
+++ b/src/main/java/kr/co/fastcampus/yanabada/domain/payment/repository/YanoljaPayRepository.java
@@ -1,11 +1,20 @@
 package kr.co.fastcampus.yanabada.domain.payment.repository;
 
+import io.lettuce.core.dynamic.annotation.Param;
+import jakarta.validation.constraints.Pattern;
 import java.util.Optional;
 import kr.co.fastcampus.yanabada.domain.member.entity.Member;
 import kr.co.fastcampus.yanabada.domain.payment.entity.YanoljaPay;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 public interface YanoljaPayRepository extends JpaRepository<YanoljaPay, Long> {
+
     Optional<YanoljaPay> findByMember(Member member);
+
+    @Modifying
+    @Query("UPDATE YanoljaPay y SET y.simplePassword = :password WHERE y.member = :member")
+    void updateSimplePassword(@Param("member") Member member, @Param("password") String password);
 }
 

--- a/src/main/java/kr/co/fastcampus/yanabada/domain/payment/repository/YanoljaPayRepository.java
+++ b/src/main/java/kr/co/fastcampus/yanabada/domain/payment/repository/YanoljaPayRepository.java
@@ -13,8 +13,5 @@ public interface YanoljaPayRepository extends JpaRepository<YanoljaPay, Long> {
 
     Optional<YanoljaPay> findByMember(Member member);
 
-    @Modifying
-    @Query("UPDATE YanoljaPay y SET y.simplePassword = :password WHERE y.member = :member")
-    void updateSimplePassword(@Param("member") Member member, @Param("password") String password);
 }
 

--- a/src/main/java/kr/co/fastcampus/yanabada/domain/payment/service/YanoljaPayService.java
+++ b/src/main/java/kr/co/fastcampus/yanabada/domain/payment/service/YanoljaPayService.java
@@ -5,7 +5,7 @@ import kr.co.fastcampus.yanabada.common.exception.PasswordConfirmationException;
 import kr.co.fastcampus.yanabada.common.exception.YanoljaPayNotFoundException;
 import kr.co.fastcampus.yanabada.domain.member.entity.Member;
 import kr.co.fastcampus.yanabada.domain.member.repository.MemberRepository;
-import kr.co.fastcampus.yanabada.domain.payment.dto.request.PayPasswordRequest;
+import kr.co.fastcampus.yanabada.domain.payment.dto.request.PayPasswordSaveRequest;
 import kr.co.fastcampus.yanabada.domain.payment.dto.response.YanoljaPayHomeResponse;
 import kr.co.fastcampus.yanabada.domain.payment.entity.YanoljaPay;
 import kr.co.fastcampus.yanabada.domain.payment.repository.YanoljaPayRepository;
@@ -35,14 +35,15 @@ public class YanoljaPayService {
     }
 
     @Transactional
-    public void setPayPassword(Long memberId, PayPasswordRequest payPasswordRequest) {
-        if (!payPasswordRequest.isPasswordMatch()) {
+    public void setPayPassword(Long memberId, PayPasswordSaveRequest payPasswordSaveRequest) {
+        if (!payPasswordSaveRequest.isPasswordMatch()) {
             throw new PasswordConfirmationException();
         }
 
-        Member member = memberRepository.findById(memberId)
-            .orElseThrow(MemberNotFoundException::new);
+        Member member = memberRepository.getMember(memberId);
+        YanoljaPay yanoljaPay = yanoljaPayRepository.findByMember(member)
+            .orElseThrow(YanoljaPayNotFoundException::new);
 
-        yanoljaPayRepository.updateSimplePassword(member, payPasswordRequest.password());
+        yanoljaPay.savePassword(payPasswordSaveRequest.password());
     }
 }

--- a/src/main/java/kr/co/fastcampus/yanabada/domain/payment/service/YanoljaPayService.java
+++ b/src/main/java/kr/co/fastcampus/yanabada/domain/payment/service/YanoljaPayService.java
@@ -1,8 +1,11 @@
 package kr.co.fastcampus.yanabada.domain.payment.service;
 
+import kr.co.fastcampus.yanabada.common.exception.MemberNotFoundException;
+import kr.co.fastcampus.yanabada.common.exception.PasswordConfirmationException;
 import kr.co.fastcampus.yanabada.common.exception.YanoljaPayNotFoundException;
 import kr.co.fastcampus.yanabada.domain.member.entity.Member;
 import kr.co.fastcampus.yanabada.domain.member.repository.MemberRepository;
+import kr.co.fastcampus.yanabada.domain.payment.dto.request.PayPasswordRequest;
 import kr.co.fastcampus.yanabada.domain.payment.dto.response.YanoljaPayHomeResponse;
 import kr.co.fastcampus.yanabada.domain.payment.entity.YanoljaPay;
 import kr.co.fastcampus.yanabada.domain.payment.repository.YanoljaPayRepository;
@@ -29,5 +32,17 @@ public class YanoljaPayService {
             .orElseThrow(YanoljaPayNotFoundException::new);
 
         return YanoljaPayHomeResponse.from(yanoljaPay);
+    }
+
+    @Transactional
+    public void setPayPassword(Long memberId, PayPasswordRequest payPasswordRequest) {
+        if (!payPasswordRequest.isPasswordMatch()) {
+            throw new PasswordConfirmationException();
+        }
+
+        Member member = memberRepository.findById(memberId)
+            .orElseThrow(MemberNotFoundException::new);
+
+        yanoljaPayRepository.updateSimplePassword(member, payPasswordRequest.password());
     }
 }


### PR DESCRIPTION
resolved #86

## 개요
야놀자 페이에서 사용할 비밀번호 등록 / 한 번 더 확인하는 API 구현
- 비밀번호는 6자리 숫자만 입력 가능
- 이전 화면에서 입력한 동일한 비밀번호 입력 확인
- 일치하면 엔드포인트를 통해 서비스로 전송
- 비밀번호 유효성 검사 후 엔티티에 저장하는 로직 포함

## PR 유형
어떤 변경 사항이 있나요?
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [x] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고  (Ctrl + 클릭하세요.)
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)